### PR TITLE
Make it possible to statically link with libpci.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,12 @@ ifeq ($(CC),"")
 CC = gcc
 endif
 
+ifdef STATIC_LIBPCI
+LIBPCI = -Wl,-Bstatic -lpci -Wl,-Bdynamic -lz
+else
+LIBPCI = -lpci
+endif
+
 SHELL = /bin/sh
 
 V	= @
@@ -60,7 +66,8 @@ X86INFO_OBJS = $(sort $(patsubst %.c,%.o,$(wildcard *.c))) \
 	$(sort $(patsubst %.c,%.o,$(wildcard vendors/*/*.c)))
 
 x86info: $(X86INFO_OBJS) $(X86INFO_HEADERS)
-	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o x86info $(X86INFO_OBJS) -lpci
+	$(QUIET_CC)$(CC) $(CFLAGS) $(LDFLAGS) -o x86info $(X86INFO_OBJS) \
+	    $(LIBPCI)
 
 DEPDIR= .deps
 -include $(X86INFO_SRC:%.c=$(DEPDIR)/%.d)


### PR DESCRIPTION
Apparently libpci is not very common library, on some hosts where I do
a work, libpci is not installed.  Still, x86info is useful for regular
users, and bothering root with the package installation is not always
reasonable.  Setting STATIC_LIBPCI var at the make command line allows
to make the custom build with statically linked libpci without editing
Makefile.
