### PR TITLE
Develop

### DIFF
--- a/features.c
+++ b/features.c
@@ -52,7 +52,9 @@ void get_feature_flags(struct cpudata *cpu)
 
 /* CPUID 0x00000006 EAX flags */
 static const char *intel_cpuid_06_eax_flags[32] = {
-	"dts", "ida", "arat", NULL, "pln", "ecmd", "ptm",
+	"dts", "ida", "arat", NULL, "pln", "ecmd", "ptm", "hwp",
+	"hwp_notify", "hwp_act_window", "hwp_epp", "hwp_lpr",
+	NULL, "hdc",
 };
 
 static const char *intel_cpuid_06_eax_flags_desc[32] = {
@@ -63,6 +65,13 @@ static const char *intel_cpuid_06_eax_flags_desc[32] = {
 	"Power limit notification controls",			// 4
 	"Clock modulation duty cycle extension",		// 5
 	"Package thermal management",				// 6
+	"HW-controlled performance states (HWP)",		// 7
+	"HWP Notification",					// 8
+	"HWP Activity Window",					// 9
+	"HWP Energy Performance Preference",			// 10
+	"HWP Package Level Request",				// 11
+	NULL,							// 12
+	"Hardware Duty Cycling",				// 13
 };
 
 /* CPUID 0x00000007 EBX flags */
@@ -282,7 +291,7 @@ static const char *intel_cap_extended_edx_flags_desc[32] = {
 /* CPUID 0x80000001 ECX flags */
 static const char *intel_cap_extended_ecx_flags[32] = {
 	"lahf_lm", NULL, NULL, NULL, NULL, "lzcnt", NULL, NULL,
-	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+	"prefetchw", NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 };
@@ -293,6 +302,9 @@ static const char *intel_cap_extended_ecx_flags_desc[32] = {
 	NULL,					    // 3
 	NULL,					    // 4
 	"LZCNT instruction",			    // 5
+	NULL,					    // 6
+	NULL,					    // 7
+	"PREFETCHW instruction",		    // 8
 };
 
 static const char *amd_cap_generic_ecx_flags[32] = {

--- a/vendors/intel/cachesize.c
+++ b/vendors/intel/cachesize.c
@@ -170,12 +170,16 @@ static const struct _cache_table DTLB_cache_table[] =
 	{ 0x5c, 128, "Data TLB: 4KB or 4MB pages, fully associative, 128 entries." },
 	{ 0x5d, 256, "Data TLB: 4KB or 4MB pages, fully associative, 256 entries." },
 	{ 0x63,   4, "Data TLB: 1GB pages, 4-way set associative, 4 entries" },
+	{ 0x64, 512, "Data TLB: 4KB pages, 4-way associative, 512 entries" },
+	{ 0xa0,  32, "Data TLB: 4KB pages, full associative, 32 entries" },
 	{ 0xb3, 128, "Data TLB: 4KB pages, 4-way associative, 128 entries" },
 	{ 0xb4, 256, "Data TLB1: 4KB pages, 4-way associative, 256 entries" },
 	{ 0xba,  64, "Data TLB1: 4KB pages, 4-way associative, 64 entries" },
 	{ 0xc0,   8, "Data TLB: 4KB or 4MB pages, 4-way associative, 8 entries" },
 	{ 0xc1,1024, "Shared L2 TLB: 4KB/2MB pages, 8-way associative, 1024 entries" },
 	{ 0xc2,  16, "Data TLB: 2MB/4MB pages, 4-way associative, 16 entries" },
+	{ 0xc3,1024, "Shared L2 TLB: 4KB/2MB pages, 6-way associative, 1536 entries" },
+	{ 0xc4,  32, "Data TLB: 2MB/4MB pages, 4-way associative, 32 entries" },
 	{ 0xca, 512, "Shared L2 TLB: 4KB pages, 4-way associative, 512 entries" },
 	{ 0, 0, NULL }
 };

--- a/vendors/intel/identify-family6-extended.c
+++ b/vendors/intel/identify-family6-extended.c
@@ -179,7 +179,11 @@ static struct cpu_name_def intel_fam6e_names[] = {
 
 	{ .model = 0x57, .flags = ONLYMODEL, .str = "Xeon Phi [Knights Landing]" },
 
+	{ .model = 0x5a, .flags = ONLYMODEL, .str = "Atom E3500" },
+
 	{ .model = 0x5c, .flags = ONLYMODEL, .str = "Atom [Goldmont]" },
+
+	{ .model = 0x5d, .flags = ONLYMODEL, .str = "Atom X3-C3000 [Silvermont]" },
 
 	{ .model = 0x5e, .flags = ONLYMODEL, .str = "Core-i7 [Skylake desktop]" },
 


### PR DESCRIPTION
- Add PREFETCHW instruction flag.
- Add Hardware Duty Cycling flag.
- Add HW-controlled performance states (HWP) flags.
- Add 0x64, 0xa0, 0xc3 and 0xc4 into DTLB_cache_table[].
