### PR TITLE
 Fix identify-family6-extended.c::get_namestring() to print cpu modeｌ name correctｌy.

### DIFF
--- a/vendors/intel/identify-family6-extended.c
+++ b/vendors/intel/identify-family6-extended.c
@@ -207,13 +207,13 @@ static const char * get_namestring(struct cpudata *cpu)
 		if (model(cpu) != intel_fam6e_names[i].model)
 			continue;
 
-		if (intel_fam6e_names[i].flags &= ~ONLYMODEL)
+		if (intel_fam6e_names[i].flags & ONLYMODEL)
 			return intel_fam6e_names[i].str;
 
 		if (intel_fam6e_names[i].mhz > 0) {
 			if (intel_fam6e_names[i].mhz != cpu->MHz)
 				continue;
-			if (intel_fam6e_names[i].flags &= ~ONLYMHZ)
+			if (intel_fam6e_names[i].flags & ONLYMHZ)
 				return intel_fam6e_names[i].str;
 		}
 


### PR DESCRIPTION
When I tested on a Kaby Lake machine, it showed:

	CPU Model (x86info's best guess): Unknown model.

even though it had 0x9e. This diff fix the problem (for ONLYMODEL flag).
After fix, it shows:

	CPU Model (x86info's best guess): [Kabylake desktop]

It also fixes ONLYMHZ flag though it's not used.