### PR TITLE
Fix cache decoding on FreeBSD.

### DIFF
--- a/cpuid-freebsd.c
+++ b/cpuid-freebsd.c
@@ -39,7 +39,7 @@ void cpuid(unsigned int CPU_number, unsigned long long idx,
 	static int nodriver=0;
 	char cpuname[20];
 	int fh;
-	cpuctl_cpuid_args_t args;
+	cpuctl_cpuid_count_args_t args;
 
 	if (nodriver == 1) {
 		if (native_cpuid(CPU_number, idx, eax,ebx,ecx,edx))
@@ -48,11 +48,12 @@ void cpuid(unsigned int CPU_number, unsigned long long idx,
 	}
 
 	args.level = idx;
+	args.level_type = idx >> 32;
 	/* Ok, use the /dev/CPU interface in preference to the _up code. */
 	(void)snprintf(cpuname, sizeof(cpuname), "/dev/cpuctl%u", CPU_number);
 	fh = open(cpuname, O_RDONLY);
 	if (fh != -1) {
-		if (ioctl(fh, CPUCTL_CPUID, &args) != 0) {
+		if (ioctl(fh, CPUCTL_CPUID_COUNT, &args) != 0) {
 			perror(cpuname);
 			exit(EXIT_FAILURE);
 		}

--- a/cpuid.c
+++ b/cpuid.c
@@ -21,14 +21,7 @@ int native_cpuid(unsigned int cpunr, unsigned long long idx,
 {
 	unsigned int a = 0, b = 0, c = 0, d = 0;
 
-	if (eax != NULL)
-		a = *eax;
-	if (ebx != NULL)
-		b = *ebx;
-	if (ecx != NULL)
-		c = *ecx;
-	if (edx != NULL)
-		d = *edx;
+	c = idx >> 32;
 
 	bind_cpu(cpunr);
 


### PR DESCRIPTION
cpuid4() needs special handling of upper word of idx.  Apparently FreeBSD cpuid() and native_cpuid() were  not updated.